### PR TITLE
feat: add backstage source location annotation to XRD

### DIFF
--- a/xrd.yaml
+++ b/xrd.yaml
@@ -15,6 +15,7 @@ metadata:
     backstage.io/title: "Cloudflare DNS Record v1.0.2"
     backstage.io/version: "1.0.2"
     backstage.io/description: "Create and manage DNS records in Cloudflare with automatic zone configuration"
+    backstage.io/source-location: "url:https://github.com/open-service-portal/template-cloudflare-dnsrecord"
     # Version as a tag for visibility
     terasky.backstage.io/tags: "v1.0.2,dns,cloudflare"
     # Terasky specific


### PR DESCRIPTION
## Summary
- Add `backstage.io/source-location` annotation to XRD
- Points to GitHub repository URL for direct source code navigation
- Enables better integration with Backstage catalog

## Test plan
- [ ] Verify XRD still applies successfully to cluster
- [ ] Confirm annotation appears in Backstage catalog
- [ ] Test source location link navigates correctly

🤖 Generated with [Claude Code](https://claude.ai/code)