### PR TITLE
feat: add GitHub project-slug annotation for Backstage catalog

### DIFF
--- a/xrd.yaml
+++ b/xrd.yaml
@@ -16,6 +16,7 @@ metadata:
     backstage.io/version: "1.0.2"
     backstage.io/description: "Create and manage DNS records in Cloudflare with automatic zone configuration"
     backstage.io/source-location: "url:https://github.com/open-service-portal/template-cloudflare-dnsrecord"
+    github.com/project-slug: "open-service-portal/template-cloudflare-dnsrecord"
     # Version as a tag for visibility
     terasky.backstage.io/tags: "v1.0.2,dns,cloudflare"
     # Terasky specific


### PR DESCRIPTION
## Summary
- Added `github.com/project-slug` annotation to XRD metadata
- Enables proper GitHub integration in Backstage catalog
- Maintains existing `backstage.io/source-location` for compatibility

## Purpose
The `github.com/project-slug` annotation is the standard way to link Backstage entities to their GitHub repositories. This enables:
- GitHub repository linking with "View Source" button
- Integration with GitHub Issues and PRs
- Repository statistics display
- GitHub Actions integration (if configured)

## Changes
- Added line 19 in `xrd.yaml`: `github.com/project-slug: "open-service-portal/template-cloudflare-dnsrecord"`

## Test Plan
- [ ] Deploy updated XRD to cluster
- [ ] Verify template appears in Backstage catalog
- [ ] Confirm GitHub repository link is displayed correctly
- [ ] Check that "View on GitHub" button works

🤖 Generated with Claude Code
https://claude.ai/code