### PR TITLE
feat: migrate XRD group from platform.io to openportal.dev

### DIFF
--- a/composition.yaml
+++ b/composition.yaml
@@ -10,7 +10,7 @@ metadata:
     type: dns-record
 spec:
   compositeTypeRef:
-    apiVersion: platform.io/v1alpha1
+    apiVersion: openportal.dev/v1alpha1
     kind: CloudflareDNSRecord
   
   mode: Pipeline
@@ -102,7 +102,7 @@ spec:
             {{- $fqdn = $zone }}
           {{- end }}
           
-          apiVersion: platform.io/v1alpha1
+          apiVersion: openportal.dev/v1alpha1
           kind: CloudflareDNSRecord
           status:
             fqdn: {{ $fqdn }}

--- a/examples/a-record.yaml
+++ b/examples/a-record.yaml
@@ -1,5 +1,5 @@
 # Example: Create an A record in Cloudflare
-apiVersion: platform.io/v1alpha1
+apiVersion: openportal.dev/v1alpha1
 kind: CloudflareDNSRecord
 metadata:
   name: myapp-dns

--- a/examples/cname.yaml
+++ b/examples/cname.yaml
@@ -1,5 +1,5 @@
 # Example: Create a CNAME record in Cloudflare
-apiVersion: platform.io/v1alpha1
+apiVersion: openportal.dev/v1alpha1
 kind: CloudflareDNSRecord
 metadata:
   name: www-dns

--- a/examples/record-with-zone-selection.yaml
+++ b/examples/record-with-zone-selection.yaml
@@ -9,7 +9,7 @@
 
 ---
 # Example 1: Create record in default zone (openportal-zone)
-apiVersion: platform.io/v1alpha1
+apiVersion: openportal.dev/v1alpha1
 kind: CloudflareDNSRecord
 metadata:
   name: app-default-zone
@@ -23,7 +23,7 @@ spec:
 
 ---
 # Example 2: Create record in a specific zone
-apiVersion: platform.io/v1alpha1
+apiVersion: openportal.dev/v1alpha1
 kind: CloudflareDNSRecord
 metadata:
   name: app-staging-zone
@@ -37,7 +37,7 @@ spec:
 
 ---
 # Example 3: Create record with zone reference
-apiVersion: platform.io/v1alpha1
+apiVersion: openportal.dev/v1alpha1
 kind: CloudflareDNSRecord
 metadata:
   name: api-endpoint

--- a/xrd.yaml
+++ b/xrd.yaml
@@ -4,7 +4,7 @@
 apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
-  name: cloudflarednsrecords.platform.io
+  name: cloudflarednsrecords.openportal.dev
   labels:
     terasky.backstage.io/generate-form: "true"
     version: "v1.0.2"
@@ -30,7 +30,7 @@ metadata:
     terasky.backstage.io/auto-apply: 'true'
 spec:
   scope: Namespaced  # Crossplane v2 - XRs can be created in any namespace
-  group: platform.io
+  group: openportal.dev
   names:
     kind: CloudflareDNSRecord
     plural: cloudflarednsrecords


### PR DESCRIPTION
## Summary
- Migrate XRD group from `platform.io` to `openportal.dev` for consistency
- Update all API versions in XRD, Composition, and examples

## Changes
- Updated XRD name from `cloudflarednsrecords.platform.io` to `cloudflarednsrecords.openportal.dev`
- Updated group from `platform.io` to `openportal.dev`
- Updated all apiVersion references from `platform.io/v1alpha1` to `openportal.dev/v1alpha1`

## Benefits
- Consistent domain naming across all templates
- Better branding with openportal.dev domain
- Clearer ownership of resources