### PR TITLE
fix: remove status.provider field from Composition

### DIFF
--- a/configuration/composition.yaml
+++ b/configuration/composition.yaml
@@ -120,7 +120,6 @@ spec:
           kind: CloudflareDNSRecord
           status:
             fqdn: {{ $fqdn }}
-            provider: external-dns
   
   # Step 4: Mark as ready when DNSEndpoint is created
   - step: auto-ready


### PR DESCRIPTION
## Summary
Fixes XR reconciliation error by removing the undefined `status.provider` field from the Composition.

## Problem
The v2.0.0 Composition was trying to set `status.provider: external-dns` in the update-status pipeline step, but this field doesn't exist in the XRD schema. This caused XRs to fail reconciliation with the error:
```
cannot compose resources: cannot apply composite resource status: 
failed to create typed patch object: .status.provider: field not declared in schema
```

## Solution
Remove the `provider` field from the status update. The XRD only defines these status fields:
- `fqdn` - Fully qualified domain name
- `ready` - Whether the record is ready
- `recordId` - Cloudflare record ID

## Changes
- Removed `provider: external-dns` from the update-status pipeline step
- Status now only sets the `fqdn` field which exists in the schema

## Testing
- [x] Composition applies without errors
- [x] XRs can reconcile successfully
- [x] Status updates work with only the fqdn field

## Impact
- Fixes XR reconciliation for all CloudflareDNSRecord resources
- No functional impact - the provider field was informational only
- Existing XRs will start working once the Composition is updated

## Related
- Introduced in PR #5 during External-DNS migration
- Part of v2.0.0 release