### PR TITLE
fix: add version label and fix yq workflow corruption

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,8 +71,7 @@ jobs:
 
       - name: Build Configuration package
         run: |
-          # Add version to package metadata
-          yq -i '.metadata.labels."openportal.dev/version" = env(VERSION)' configuration/crossplane.yaml
+          # Add version label to XRD only (crossplane.yaml has multi-line strings that yq corrupts)
           yq -i '.metadata.labels."openportal.dev/version" = env(VERSION)' configuration/xrd.yaml
 
           # Build the .xpkg file

--- a/configuration/xrd.yaml
+++ b/configuration/xrd.yaml
@@ -7,6 +7,7 @@ metadata:
   name: cloudflarednsrecords.openportal.dev
   labels:
     terasky.backstage.io/generate-form: "true"
+    openportal.dev/version: "dev"  # CI/CD will replace with actual version
   annotations:
     crossplane.io/version: "v2.0"
     description: "Manage real DNS records in Cloudflare"


### PR DESCRIPTION
## Summary
- Add `openportal.dev/version: "dev"` placeholder to XRD
- Fix GitHub Actions workflow to only use yq on XRD files
- Prevents YAML corruption from yq processing multi-line strings

## Context
Part of standardizing version labeling across all templates. The workflow was previously using yq on crossplane.yaml which can corrupt multi-line strings.

## Changes
- Added version label to XRD as placeholder for CI/CD
- Updated release workflow to only modify XRD with yq
- Follows new template standards documented in portal-workspace

This ensures proper version tracking without YAML corruption during releases.